### PR TITLE
numpy and scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+numpy
+scipy
 opencv
 scikit-image
 imutils
-numpy


### PR DESCRIPTION
opencv requires numpy and scipy install before attempting to install opencv itself.